### PR TITLE
Allow definition of multiple source directories

### DIFF
--- a/src/it/basic/pom.xml
+++ b/src/it/basic/pom.xml
@@ -24,7 +24,9 @@
               <failOnViolation>true</failOnViolation>
               <includeTestSourceDirectory>true</includeTestSourceDirectory>
               <failOnWarning>false</failOnWarning>
-              <sourceDirectory>${src.it}/testsrc</sourceDirectory>
+              <sourceDirectories>
+                <dir>${src.it}/testsrc</dir>
+              </sourceDirectories>
               <configLocation>${src.it}/scalastyle_config.xml</configLocation>
                 
                 </configuration>

--- a/src/it/checkstyle_xml/pom.xml
+++ b/src/it/checkstyle_xml/pom.xml
@@ -22,7 +22,9 @@
           <failOnViolation>true</failOnViolation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <failOnWarning>false</failOnWarning>
-          <sourceDirectory>${src.it}/testsrc</sourceDirectory>
+          <sourceDirectories>
+            <dir>${src.it}/testsrc</dir>
+          </sourceDirectories>
           <configLocation>${src.it}/scalastyle_config.xml</configLocation>
           <outputFile>${project.basedir}/scalastyle-output.xml</outputFile>
           <outputEncoding>UTF-16</outputEncoding>

--- a/src/it/input_encoding/pom.xml
+++ b/src/it/input_encoding/pom.xml
@@ -24,7 +24,9 @@
               <failOnViolation>true</failOnViolation>
               <includeTestSourceDirectory>true</includeTestSourceDirectory>
               <failOnWarning>false</failOnWarning>
-              <sourceDirectory>${project.basedir}/src</sourceDirectory>
+              <sourceDirectories>
+                <dir>${project.basedir}/src</dir>
+              </sourceDirectories>
               <configLocation>${src.it}/scalastyle_config.xml</configLocation>
               <inputEncoding>UTF-16</inputEncoding>
                 

--- a/src/it/no_config/pom.xml
+++ b/src/it/no_config/pom.xml
@@ -24,7 +24,9 @@
               <failOnViolation>true</failOnViolation>
               <includeTestSourceDirectory>true</includeTestSourceDirectory>
               <failOnWarning>true</failOnWarning>
-              <sourceDirectory>${src.it}/testsrc</sourceDirectory>
+              <sourceDirectories>
+                <dir>${src.it}/testsrc</dir>
+              </sourceDirectories>
               <configLocation>${src.it}/this.does.not.exist.xml</configLocation>
                 
                 </configuration>


### PR DESCRIPTION
I made it possible to add multiple source dirs.

Main points:
- `stdTestSourceDirectory` is needed to specify a default value if one doesn't specify anything. This is ugly and it is possible to set this value from the configuration. Any ideas on how to fix this?
- No @required attribute for source directories anymore. If one doesn't specify anything, nothing is done.
- I didn't came up with a test case. Any ideas on how to test the new behavior?
- Probably the SBT plugin and the command line tool needs to be updated too. I didn't look at them yet (documentation of course as well).

Do you like the changes? Maybe you have an even better idea on how to realize the definition of multiple dirs.
